### PR TITLE
fix(build): specify clang's arch flag on macOS

### DIFF
--- a/concrete-fftw-sys/build.rs
+++ b/concrete-fftw-sys/build.rs
@@ -17,6 +17,35 @@ fn run(command: &mut Command) {
     }
 }
 
+fn set_common_configure_arguments(configure: &mut Command, c_target: &'static str) {
+    configure
+        .arg("--with-pic")
+        .arg("--enable-static")
+        .arg("--disable-doc");
+
+    if c_target == "x86_64" {
+        configure
+            .arg("--enable-avx")
+            .arg("--enable-avx2")
+            .arg("--enable-sse2")
+            .arg("--enable-generic-simd128")
+            .arg("--enable-generic-simd256");
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // This flag only works for clang,
+        // which is the default and most common compiler used on macOS
+        // However, gcc also exists on macOS, so using gcc would not work.
+        // Let's just say we do not support gcc on macOs.
+        if c_target == "arm64" {
+            configure.arg("CFLAGS=-arch arm64");
+        } else if c_target == "x86_64" {
+            configure.arg("CFLAGS=-arch x86_64");
+        }
+    }
+}
+
 fn main() {
     // ========================================================================= Check configuration
     if cfg!(windows) {
@@ -25,6 +54,17 @@ fn main() {
     if cfg!(macos) && cfg!(feature = "mkl") {
         panic!("Mkl is not supported in the macos platform.")
     }
+
+    let rust_target = std::env::var("TARGET").unwrap();
+    let c_target: &'static str;
+    if rust_target.contains("x86_64") {
+        c_target = "x86_64";
+    } else if rust_target.contains("aarch64") {
+        c_target = "arm64";
+    } else {
+        panic!("This target is not supported");
+    }
+
     // ================================================================================ Copy sources
     let out_dir = PathBuf::from(var("OUT_DIR").unwrap());
     let src_dir = PathBuf::from(var("CARGO_MANIFEST_DIR").unwrap()).join("fftw-3.3.8");
@@ -45,17 +85,11 @@ fn main() {
 
     // ===================================================================================== Compile
     let mut configure = Command::new(canonicalize(out_src_dir.join("configure")).unwrap());
+    set_common_configure_arguments(&mut configure, c_target);
     configure
-        .arg("--with-pic")
-        .arg("--enable-static")
-        .arg("--enable-avx")
-        .arg("--enable-avx2")
-        .arg("--enable-sse2")
-        .arg("--enable-generic-simd128")
-        .arg("--enable-generic-simd256")
-        .arg("--disable-doc")
         .arg(format!("--prefix={}", out_dir.display()))
         .current_dir(&out_src_dir);
+
     run(&mut configure);
     run(Command::new("make")
         .arg(format!("-j{}", var("NUM_JOBS").unwrap()))
@@ -66,19 +100,12 @@ fn main() {
 
     // run(Command::new("make distclean").current_dir(&out_src_dir));
     let mut configure = Command::new(canonicalize(out_src_dir.join("configure")).unwrap());
+    set_common_configure_arguments(&mut configure, c_target);
     configure
-        .arg("--with-pic")
-        .arg("--enable-static")
         .arg("--enable-single")
-        .arg("--enable-avx")
-        .arg("--enable-avx2")
-        .arg("--enable-sse")
-        .arg("--enable-sse2")
-        .arg("--enable-generic-simd128")
-        .arg("--enable-generic-simd256")
-        .arg("--disable-doc")
         .arg(format!("--prefix={}", out_dir.display()))
         .current_dir(&out_src_dir);
+
     run(&mut configure);
     run(Command::new("make")
         .arg(format!("-j{}", var("NUM_JOBS").unwrap()))

--- a/concrete-fftw/Cargo.toml
+++ b/concrete-fftw/Cargo.toml
@@ -15,7 +15,7 @@ serialize = ["num-complex/serde", "serde"]
 mkl = ["concrete-fftw-sys/mkl"]
 
 [dependencies]
-concrete-fftw-sys = "=0.1.2"
+concrete-fftw-sys = {version = "0.1.3", path = "../concrete-fftw-sys" }
 bitflags = "1.2.1"
 lazy_static = "1.4.0"
 num-complex = "0.4.0"


### PR DESCRIPTION
This fixes 2 things:

- Cross compiling to x86_64, for example from an apple silicon enabled mac
  to x86_64 when passing the `--target=x86_64-apple-darwin` argument to cargo
- Compiling for `arm64`

What happened before on a M1 enabled mac is that compiling with
```console
cargo test --target x86_64-apple-darwin
```
Would successfully build but fails to run tests with errors like:
`archive member 'malloc.o' with length 856 is not mach-o or llvm bitcode`
because the configure script would compile the fftw's C code
for the arm target while rust targets x86.

The fix is to detect which target rust is targeting
and set the `arch` flags to the matching target value.