### PR TITLE
Make concrete-fftw-sys cross-platform

### DIFF
--- a/concrete-fftw-sys/Cargo.toml
+++ b/concrete-fftw-sys/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 
 [build-dependencies]
 fs_extra = "~1.2.0"
+path-absolutize = "~3.0.11"
 
 [features]
 mkl = ["intel-mkl-src"]

--- a/concrete-fftw-sys/README.md
+++ b/concrete-fftw-sys/README.md
@@ -4,7 +4,45 @@ This library contains an unsafe wrapper of the FFTW library.
 
 To compile with fftw, you need to have libclang installed on your computer.
 
-# Fork
+## Fork
 
 This crate is a fork of the [rust-math/fftw](https://github.com/rust-math/fftw) wrapper of the 
 FFTW library.
+
+## Building
+
+The `build.rs` script to compile this library needs the `cmake` and `ninja` build tools. Instructions on how to install these tools for different platforms:
+
+### Linux
+
+#### Debian/Ubuntu
+
+```
+sudo apt install cmake ninja-build
+```
+
+#### Fedora/Red Hat
+
+```
+sudo yum install cmake ninja-build
+```
+
+### MacOS
+
+Assuming Homebrew is installed:
+
+```
+brew install cmake ninja
+```
+
+### Windows
+
+First, install [Visual Studio Community](https://visualstudio.microsoft.com/vs/community/) from the Microsoft website. In the installer, get "Desktop Development for C++" under the Workloads tab, and "C++ CMake tools for Windows" under the Individual Components tab.
+
+When compiling a project that uses this library, you must do so from a command prompt that has access to `cmake` and `ninja`. Assuming you installed Visual Studio 2022 to its default location, you can open a terminal with these tools by running:
+
+```
+cmd.exe /k "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+```
+
+You can then run `cargo build` from within this terminal.

--- a/concrete-fftw/src/array.rs
+++ b/concrete-fftw/src/array.rs
@@ -1,5 +1,6 @@
 //! Array with SIMD alignment
 
+use std::convert::TryInto;
 use std::ops::{Deref, DerefMut};
 use std::os::raw::c_void;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
@@ -26,25 +27,25 @@ pub trait AlignedAllocable: Zero + Clone + Copy + Sized {
 
 impl AlignedAllocable for f64 {
     unsafe fn alloc(n: usize) -> *mut Self {
-        ffi::fftw_alloc_real(n as u64)
+        ffi::fftw_alloc_real(n.try_into().unwrap())
     }
 }
 
 impl AlignedAllocable for f32 {
     unsafe fn alloc(n: usize) -> *mut Self {
-        ffi::fftwf_alloc_real(n as u64)
+        ffi::fftwf_alloc_real(n.try_into().unwrap())
     }
 }
 
 impl AlignedAllocable for c64 {
     unsafe fn alloc(n: usize) -> *mut Self {
-        ffi::fftw_alloc_complex(n as u64) as *mut _
+        ffi::fftw_alloc_complex(n.try_into().unwrap()) as *mut _
     }
 }
 
 impl AlignedAllocable for c32 {
     unsafe fn alloc(n: usize) -> *mut Self {
-        ffi::fftwf_alloc_complex(n as u64) as *mut c32
+        ffi::fftwf_alloc_complex(n.try_into().unwrap()) as *mut c32
     }
 }
 


### PR DESCRIPTION
Tested by compiling a simple app on Windows 10 that uses `concrete`. Can do more rigorous tests  for Windows/Linux on request, although no functionality has changed really.

Any feedback is appreciated :)