### PR TITLE
fix(build): specify clang's `arch` flag on macOS

### DIFF
--- a/concrete-fftw-sys/build.rs
+++ b/concrete-fftw-sys/build.rs
@@ -1,7 +1,25 @@
+use std::convert::{TryFrom, TryInto};
 use std::env::var;
 use std::fs::canonicalize;
 use std::path::PathBuf;
 use std::process::Command;
+
+enum TargetArch {
+    X86_64,
+    Aarch64,
+}
+
+impl TryFrom<String> for TargetArch {
+    type Error = String;
+
+    fn try_from(string: String) -> Result<Self, Self::Error> {
+        match string.to_lowercase().as_str() {
+            "x86_64" => Ok(Self::X86_64),
+            "aarch64" => Ok(Self::Aarch64),
+            _ => Err(format!("This target '{}' is not supported", string)),
+        }
+    }
+}
 
 fn run(command: &mut Command) {
     println!("Running: {:?}", command);
@@ -17,6 +35,39 @@ fn run(command: &mut Command) {
     }
 }
 
+fn set_common_configure_arguments(configure: &mut Command, target_arch: &TargetArch) {
+    configure
+        .arg("--with-pic")
+        .arg("--enable-static")
+        .arg("--disable-doc");
+
+    // The -arch flag only works for clang, which is the default and most common compiler used on
+    // macOS. However, gcc also exists on macOS, so using gcc would not work for now.
+    match target_arch {
+        TargetArch::Aarch64 => {
+            // No generic simd here as it's gcc specific and is not the compiler of choice on macOS
+            // TODO this only works for single precision, check if we can have neon in general
+            // configure.arg("--enable-neon");
+
+            if cfg!(macos) {
+                configure.arg("CFLAGS=-arch aarch64");
+            }
+        }
+        TargetArch::X86_64 => {
+            configure
+                .arg("--enable-avx")
+                .arg("--enable-avx2")
+                .arg("--enable-sse2")
+                .arg("--enable-generic-simd128")
+                .arg("--enable-generic-simd256");
+
+            if cfg!(macos) {
+                configure.arg("CFLAGS=-arch x86_64");
+            }
+        }
+    }
+}
+
 fn main() {
     // ========================================================================= Check configuration
     if cfg!(windows) {
@@ -25,6 +76,12 @@ fn main() {
     if cfg!(macos) && cfg!(feature = "mkl") {
         panic!("Mkl is not supported in the macos platform.")
     }
+
+    let target_arch: TargetArch = std::env::var("CARGO_CFG_TARGET_ARCH")
+        .expect("CARGO_CFG_TARGET_ARCH is not set")
+        .try_into()
+        .unwrap();
+
     // ================================================================================ Copy sources
     let out_dir = PathBuf::from(var("OUT_DIR").unwrap());
     let src_dir = PathBuf::from(var("CARGO_MANIFEST_DIR").unwrap()).join("fftw-3.3.8");
@@ -45,17 +102,11 @@ fn main() {
 
     // ===================================================================================== Compile
     let mut configure = Command::new(canonicalize(out_src_dir.join("configure")).unwrap());
+    set_common_configure_arguments(&mut configure, &target_arch);
     configure
-        .arg("--with-pic")
-        .arg("--enable-static")
-        .arg("--enable-avx")
-        .arg("--enable-avx2")
-        .arg("--enable-sse2")
-        .arg("--enable-generic-simd128")
-        .arg("--enable-generic-simd256")
-        .arg("--disable-doc")
         .arg(format!("--prefix={}", out_dir.display()))
         .current_dir(&out_src_dir);
+
     run(&mut configure);
     run(Command::new("make")
         .arg(format!("-j{}", var("NUM_JOBS").unwrap()))
@@ -66,19 +117,12 @@ fn main() {
 
     // run(Command::new("make distclean").current_dir(&out_src_dir));
     let mut configure = Command::new(canonicalize(out_src_dir.join("configure")).unwrap());
+    set_common_configure_arguments(&mut configure, &target_arch);
     configure
-        .arg("--with-pic")
-        .arg("--enable-static")
         .arg("--enable-single")
-        .arg("--enable-avx")
-        .arg("--enable-avx2")
-        .arg("--enable-sse")
-        .arg("--enable-sse2")
-        .arg("--enable-generic-simd128")
-        .arg("--enable-generic-simd256")
-        .arg("--disable-doc")
         .arg(format!("--prefix={}", out_dir.display()))
         .current_dir(&out_src_dir);
+
     run(&mut configure);
     run(Command::new("make")
         .arg(format!("-j{}", var("NUM_JOBS").unwrap()))

--- a/concrete-fftw/Cargo.toml
+++ b/concrete-fftw/Cargo.toml
@@ -15,7 +15,7 @@ serialize = ["num-complex/serde", "serde"]
 mkl = ["concrete-fftw-sys/mkl"]
 
 [dependencies]
-concrete-fftw-sys = "=0.1.2"
+concrete-fftw-sys = "=0.1.3"
 bitflags = "1.2.1"
 lazy_static = "1.4.0"
 num-complex = "0.4.0"

--- a/concrete-fftw/src/plan.rs
+++ b/concrete-fftw/src/plan.rs
@@ -35,8 +35,7 @@ pub struct Plan<A, B, Plan: PlanSpec> {
     phantom: PhantomData<(A, B)>,
 }
 
-unsafe impl<A: Send, B: Send> Send for Plan<A, B, Plan32> {}
-unsafe impl<A: Send, B: Send> Send for Plan<A, B, Plan64> {}
+unsafe impl<A, B, Spec: PlanSpec> Send for Plan<A, B, Spec> {}
 
 impl<A, B, P: PlanSpec> Drop for Plan<A, B, P> {
     fn drop(&mut self) {


### PR DESCRIPTION
This PR is the same as https://github.com/zama-ai/concrete-fftw/pull/10 but with the management through env variable as suggested by @tmontaigu 

All credit goes to him, I merely rewrote it the way he mentionned.

With this merged a new release of concrete-fftw will be M1 compatible