### PR TITLE
chore(deps): disable mkl as it is broken at the moment

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: ["", "mkl", "serialize"]
+        feature: ["", "serialize"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/cargo@v1
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: ["", "mkl", "serialize"]
+        feature: ["", "serialize"]
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/cargo@v1

--- a/concrete-fftw-sys/Cargo.toml
+++ b/concrete-fftw-sys/Cargo.toml
@@ -15,11 +15,7 @@ build = "build.rs"
 [build-dependencies]
 fs_extra = "~1.2.0"
 
-[features]
-mkl = ["intel-mkl-src"]
-
 [dependencies]
-intel-mkl-src = {version = "0.6.0", optional=true}
 num-complex = "0.4.0"
 
 [package.metadata.release]

--- a/concrete-fftw-sys/build.rs
+++ b/concrete-fftw-sys/build.rs
@@ -73,9 +73,6 @@ fn main() {
     if cfg!(windows) {
         panic!("Windows platform is not supported.")
     }
-    if cfg!(macos) && cfg!(feature = "mkl") {
-        panic!("Mkl is not supported in the macos platform.")
-    }
 
     let target_arch: TargetArch = std::env::var("CARGO_CFG_TARGET_ARCH")
         .expect("CARGO_CFG_TARGET_ARCH is not set")

--- a/concrete-fftw-sys/src/lib.rs
+++ b/concrete-fftw-sys/src/lib.rs
@@ -7,16 +7,11 @@
 use f128::f128;
 use num_complex::Complex;
 
-#[cfg(not(feature = "mkl"))]
 #[link(name = "fftw3")]
 extern "C" {}
 
-#[cfg(not(feature = "mkl"))]
 #[link(name = "fftw3f")]
 extern "C" {}
-
-#[cfg(feature = "mkl")]
-extern crate intel_mkl_src as ffi;
 
 #[cfg(target_os = "macos")]
 type __darwin_size_t = std::os::raw::c_ulong;

--- a/concrete-fftw/Cargo.toml
+++ b/concrete-fftw/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["fftw", "fft", "fully", "homomorphic", "fhe"]
 
 [features]
 serialize = ["num-complex/serde", "serde"]
-mkl = ["concrete-fftw-sys/mkl"]
 
 [dependencies]
 concrete-fftw-sys = "=0.1.3"

--- a/concrete-fftw/LICENSE.txt
+++ b/concrete-fftw/LICENSE.txt
@@ -1,22 +1,10 @@
 License of concrete-fftw
 ========================
 
-`concrete-fftw` is distributed under dual license based on which backends are linked:
-
-FFTW
-------
-When using `concrete-fftw` without the "mkl" feature flag, FFTW is used as a backend. FFTW is free
-software and distributed under [GNU General Public License version 2 (GPLv2)](https://www.gnu.org/licenses/gpl-2.0.html)
-or (at your option) any later version. In this case, `concrete-fftw` is also distributed under GPLv2
-or later.
-
-Intel MKL
----------
-When using `concrete-fftw` with the "mkl" feature flag, Intel Math Kernel Library (MKL) is used as a
-backend. MKL is distributed under the
-[Intel Simplified Software License](https://software.intel.com/en-us/license/intel-simplified-software-license).
-See also [License FAQ](https://software.intel.com/en-us/mkl/license-faq).
-In this case, `concrete-fftw` is distributed under the following MIT-license:
+When using `concrete-fftw`, FFTW is used as a backend. FFTW is free software and distributed under
+[GNU General Public License version 2 (GPLv2)](https://www.gnu.org/licenses/gpl-2.0.html) or (at
+your option) any later version. In this case, `concrete-fftw` is also distributed under GPLv2 or
+later.
 
     Copyright for portions of project concrete-fftw are held by Toshiki Teramura 2019 as part
     of project rust-fftw. All other copyright for project concrete-fftw are held by Zama 2021.


### PR DESCRIPTION
For now remove the mkl feature and update the CI file.

intel mkl crate seems to be left to its own fate and currently does not compile, we remove it for the time being before a more permanent solution.

closes #14 