### PR TITLE
fix: remove flag causing issues when combined with the others on some OSes

### DIFF
--- a/concrete-fftw-sys/Cargo.toml
+++ b/concrete-fftw-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "concrete-fftw-sys"
-version = "0.1.3"
-edition = "2018"
+version = "0.1.4"
+edition = "2021"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license = "GPL-2.0-or-later"
 description = "Sources of FFTW and unsafe binding"

--- a/concrete-fftw-sys/build.rs
+++ b/concrete-fftw-sys/build.rs
@@ -58,8 +58,9 @@ fn set_common_configure_arguments(configure: &mut Command, target_arch: &TargetA
                 .arg("--enable-avx")
                 .arg("--enable-avx2")
                 .arg("--enable-sse2")
-                .arg("--enable-generic-simd128")
-                .arg("--enable-generic-simd256");
+                .arg("--enable-generic-simd128");
+            // TODO: revert once fixed in fftw
+            // .arg("--enable-generic-simd256");
 
             if cfg!(macos) {
                 configure.arg("CFLAGS=-arch x86_64");

--- a/concrete-fftw/Cargo.toml
+++ b/concrete-fftw/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "concrete-fftw"
-version = "0.1.3"
-edition = "2018"
+version = "0.1.4"
+edition = "2021"
 authors = ["D. Ligier", "J.B. Orfila", "A. Péré", "S. Tap", "Zama team"]
 license-file = "LICENSE.txt"
 description = "Safe wrapper around FFTW"
@@ -14,12 +14,12 @@ keywords = ["fftw", "fft", "fully", "homomorphic", "fhe"]
 serialize = ["num-complex/serde", "serde"]
 
 [dependencies]
-concrete-fftw-sys = "=0.1.3"
+concrete-fftw-sys = { version = "=0.1.4", path = "../concrete-fftw-sys" }
 bitflags = "1.2.1"
 lazy_static = "1.4.0"
 num-complex = "0.4.0"
 num-traits = "0.2.12"
-serde = { version = "1.0", optional = true}
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.125"


### PR DESCRIPTION
The issue seems to be that the plan generator sometimes puts simd256 kernels after avx/avx2 kernels which don't play nice.

Bug report here: https://github.com/FFTW/fftw3/issues/294